### PR TITLE
Resolve class-based plugin deprecation

### DIFF
--- a/lib/string-interpolation-plugin.js
+++ b/lib/string-interpolation-plugin.js
@@ -1,8 +1,9 @@
-module.exports = class StringInterpolationPlugin {
-  transform(ast) {
-    let { builders: b, parse } = this.syntax;
+module.exports = function(env) {
+  let { builders: b, parse } = env.syntax;
 
-    this.syntax.traverse(ast, {
+  return {
+    name: 'StringInterpolationPlugin',
+    visitor: {
       MustacheStatement(node) {
         if (isInterpolatedString(node.path)) {
           let value = node.path.value;
@@ -62,11 +63,9 @@ module.exports = class StringInterpolationPlugin {
           );
         }
       }
-    });
-
-    return ast;
-  }
-}
+    },
+  };
+};
 
 function isInterpolatedString(node) {
   return node.type === 'StringLiteral' && node.value.match(/{{.+}}/);


### PR DESCRIPTION
ember-source 3.27+: Using class based template compilation plugins is deprecated, please update to the functional style